### PR TITLE
Update conf/rollingcount.yaml

### DIFF
--- a/conf/rollingcount.yaml
+++ b/conf/rollingcount.yaml
@@ -27,6 +27,6 @@ topology.max.spout.pending: 200
 topology.name: "RollingCount"
 component.spout_num: 4
 component.split_bolt_num: 8
-component.count_bolt_num: 8
+component.rolling_count_bolt_num: 8
 window.length: 150  # 150s
 emit.frequency: 30  # 30s


### PR DESCRIPTION
Fixed incorrect yaml config name for rolling count benchmark. There was a mismatch between the configuration name in yaml file and the one in benchmark code. 